### PR TITLE
migrate links to new owasp area

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Note that this repository has been migrated from Mike Goodwin's [original](https://github.com/mike-goodwin/owasp-threat-dragon-desktop) , which has the issues and pull requests from March 2017 up to June 2020.
 
 <p align="center">
-  <img src="https://mike-goodwin.github.io/owasp-threat-dragon/content/images/threatdragon_logo_image.svg" width="200" alt="Threat Dragon Logo"/>
+  <img src="https://raw.githubusercontent.com/owasp/threat-dragon-desktop/master/content/images/threatdragon_logo_image.svg" width="200" alt="Threat Dragon Logo"/>
 </p>
 
 [![Github All Releases](https://img.shields.io/github/downloads/mike-goodwin/owasp-threat-dragon-desktop/total.svg)]()
@@ -24,11 +24,11 @@ from OWASP, and this expands on what Threat Dragon will achieve:
 
 The application comes in two variants:
 
-1. [**A web application**](https://github.com/mike-goodwin/owasp-threat-dragon): For the web application, models files
+1. [**A web application**](https://github.com/owasp/threat-dragon): For the web application, models files
 are stored in GitHub (other storage will become available). We are currently maintaining [a working protoype](https://threatdragon.org)
 in synch with the master code branch.
 
-2. [**A desktop application**](https://github.com/mike-goodwin/owasp-threat-dragon-desktop): This is based on
+2. [**A desktop application**](https://github.com/owasp/threat-dragon-desktop): This is based on
 [Electron](https://electron.atom.io/). There are installers available for both Windows and Mac OSX, as well as rpm and
 debian packages for Linux. For the desktop variant models are stored on the local filesystem.
 
@@ -40,7 +40,7 @@ This repository contains the files for the desktop variant.
 
 For the latest versions of code between releases, `npm` can be used to install and run Threat Dragon locally:
 
-`git clone https://github.com/mike-goodwin/owasp-threat-dragon-desktop`
+`git clone https://github.com/owasp/threat-dragon-desktop`
 
 `npm install`
 

--- a/app/layout/shell.js
+++ b/app/layout/shell.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 function shell($rootScope, $scope, $location, $route, common, datacontext, electron, threatmodellocator, VERSION) {
     var controllerId = 'shell';
@@ -204,13 +204,13 @@ function shell($rootScope, $scope, $location, $route, common, datacontext, elect
                     {
                         label: 'Submit an Issue',
                         click: function() {
-                            electron.shell.openExternal('https://github.com/mike-goodwin/owasp-threat-dragon-desktop/issues/new');
+                            electron.shell.openExternal('https://github.com/owasp/threat-dragon-desktop/issues/new');
                         }
                     },
                     {
                         label: 'Visit us on GitHub',
                         click: function() {
-                            electron.shell.openExternal('https://github.com/mike-goodwin/owasp-threat-dragon-desktop');
+                            electron.shell.openExternal('https://github.com/owasp/threat-dragon-desktop');
                         }
                     },
                     {

--- a/installer-win.js
+++ b/installer-win.js
@@ -10,10 +10,10 @@ var options = {
   exe: 'OWASP-Threat-Dragon.exe',
   noMsi: true,
   loadingGif: './content/icons/png/cupcakes-installing.gif',
-  iconUrl: 'https://raw.githubusercontent.com/mike-goodwin/owasp-threat-dragon-desktop/master/content/icons/win/td.ico',
+  iconUrl: 'https://raw.githubusercontent.com/owasp/threat-dragon-desktop/master/content/icons/win/td.ico',
   setupIcon: path.join(rootPath, 'content', 'icons', 'win', 'td.ico'),
   description: 'An open source threat modelling tool from OWASP',
-  remoteReleases: "https://github.com/mike-goodwin/owasp-threat-dragon-desktop"
+  remoteReleases: "https://github.com/owasp/threat-dragon-desktop"
 };
 
 var rl = readline.createInterface({

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "http://docs.threatdragon.org/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mike-goodwin/owasp-threat-dragon-desktop.git"
+    "url": "git://github.com/owasp/threat-dragon-desktop.git"
   },
   "dependencies": {
     "angular": "1.7.9",

--- a/tests/specs/shell_spec.js
+++ b/tests/specs/shell_spec.js
@@ -481,7 +481,7 @@ describe('shell controller', function () {
         expect(subMenu.submenu[1].label).toEqual('Submit an Issue');
         spyOn(mockElectron.shell, 'openExternal');
         subMenu.submenu[1].click();
-        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/mike-goodwin/owasp-threat-dragon-desktop/issues/new']); 
+        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/owasp/threat-dragon-desktop/issues/new']); 
     });
 
     it('Help menu third item should browse to the GitHub repo page', function() {
@@ -490,7 +490,7 @@ describe('shell controller', function () {
         expect(subMenu.submenu[2].label).toEqual('Visit us on GitHub');
         spyOn(mockElectron.shell, 'openExternal');
         subMenu.submenu[2].click();
-        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/mike-goodwin/owasp-threat-dragon-desktop']); 
+        expect(mockElectron.shell.openExternal.calls.argsFor(0)).toEqual(['https://github.com/owasp/threat-dragon-desktop']); 
     });
 
     it('Help menu fourth item should browse to the OWASP project page', function() {


### PR DESCRIPTION
This migrates most of the links to the new owasp area. We still have some links using Mike's username, for example to the demo repo and the snyk results - these can be migrated at a later date