### PR TITLE
specific MacOS keyboard shortcuts

### DIFF
--- a/app/layout/shell.js
+++ b/app/layout/shell.js
@@ -100,7 +100,7 @@ function shell($rootScope, $scope, $location, $route, common, datacontext, elect
                     },
                     {
                         label: 'Close Model',
-                        accelerator: 'CmdOrCtrl+F4',
+                        accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+W' : 'CmdOrCtrl+F4',
                         click: function() {
                             datacontext.close();
                             $location.path('/');
@@ -120,8 +120,9 @@ function shell($rootScope, $scope, $location, $route, common, datacontext, elect
                         type: 'separator'
                     },
                     {
-                        label: 'Exit',
-                        role: 'close'
+                        label: process.platform === 'darwin' ? 'Quit' : 'Exit',
+                        accelerator: process.platform === 'darwin' ? 'CmdOrCtrl+Q' : 'CmdOrCtrl+W',
+                        role: process.platform === 'darwin' ? 'quit' : 'close'
                     }
                 ]
             },

--- a/tests/specs/shell_spec.js
+++ b/tests/specs/shell_spec.js
@@ -289,7 +289,11 @@ describe('shell controller', function () {
         var template = mockElectron.Menu.buildFromTemplate.calls.argsFor(0)[0];
         var subMenu = getSubMenu(template, 'File');
         expect(subMenu.submenu[5].label).toEqual('Close Model');
-        expect(subMenu.submenu[5].accelerator).toEqual('CmdOrCtrl+F4');
+        if (process.platform === 'darwin') {
+            expect(subMenu.submenu[5].accelerator).toEqual('CmdOrCtrl+W');
+        } else {
+            expect(subMenu.submenu[5].accelerator).toEqual('CmdOrCtrl+F4');
+        }
         var click = subMenu.submenu[5].click;
 
         spyOn($scope, '$apply').and.callThrough();
@@ -333,7 +337,13 @@ describe('shell controller', function () {
     it('File menu ninth item should be exit', function() {
         var template = mockElectron.Menu.buildFromTemplate.calls.argsFor(0)[0];
         var subMenu = getSubMenu(template, 'File');
-        expect(subMenu.submenu[8].label).toEqual('Exit');
+        if (process.platform === 'darwin') {
+            expect(subMenu.submenu[8].label).toEqual('Quit');
+            expect(subMenu.submenu[8].accelerator).toEqual('CmdOrCtrl+Q');
+        } else {
+            expect(subMenu.submenu[8].label).toEqual('Exit');
+            expect(subMenu.submenu[8].accelerator).toEqual('CmdOrCtrl+W');
+        }
         expect(subMenu.submenu[8].role).toEqual('close');
     });
 


### PR DESCRIPTION
This is a fix provided by @jmiltner in issue https://github.com/mike-goodwin/owasp-threat-dragon-desktop/issues/150

- change keyboard shortcut for "Close Model" menu item to 'CmdOrCtrl+W' when platform == darwin
- change title for "Exit" menu item to "Quit" when platform == darwin
- change keyboard shortcut for "Exit"/"Quit" menu item to 'CmdOrCtrl+Q' when platform == darwin