### PR TITLE
add confirm dialog box before quit

### DIFF
--- a/main.js
+++ b/main.js
@@ -85,6 +85,13 @@ global.params = {
   url: '/'
 }
 
+//Used to communicate with the ipcRenderer on threat-dragon-core to watch for unsaved changes
+var ipc = require('electron').ipcMain;
+var diagramIsDirty = false;
+ipc.on('vmIsDirty', function(event, data){
+  diagramIsDirty = data;
+});
+
 function isCliCommand() {
   return (command != null);
 }
@@ -139,13 +146,13 @@ function winClosed() {
 
 function winIsClosing(e) {
   //To avoid showing the dialog box twice
-  if (!windowIsClosed) {
+  if (!windowIsClosed && diagramIsDirty) {
     var choice = electron.dialog.showMessageBoxSync(null,
       {
         type: 'question',
         buttons: ['Yes', 'No'],
         title: 'Confirm',
-        message: 'Are you sure you want to quit?'
+        message: 'You have unsaved changes. Are you sure you want to quit?'
       });
 
     if (choice == 1) {

--- a/main.js
+++ b/main.js
@@ -190,6 +190,8 @@ function createMainWindow(show = true, displayWidth = -1, displayHeight = -1) {
     require('electron').shell.openExternal(url);
   });
 
+  //Workaround: The before-quit seems to be called after quitting when used on Windows and Linux from the cmd line.
+  //An additional event 'close' is put on win to fix that
   win.on('close', winIsClosing);
 
   win.on('closed', winClosed);
@@ -197,8 +199,6 @@ function createMainWindow(show = true, displayWidth = -1, displayHeight = -1) {
   return win;
 }
 
-//Workaround: The before-quit seems to be called after quitting when used on Windows and Linux from the cmd line.
-//An additional event 'close' is put on win to fix that
 app.on('before-quit', (e) => {
   winIsClosing(e);
 });

--- a/main.js
+++ b/main.js
@@ -130,7 +130,7 @@ function doCommand() {
   return win;
 }
 
-function onClosed() {
+function winClosed() {
   // dereference the window
   mainWindow = null;
 }
@@ -162,17 +162,35 @@ function createMainWindow(show = true, displayWidth = -1, displayHeight = -1) {
   log.info('Calling Threat Dragon from command line');
 
   win.loadURL(modalPath);
-  win.on('closed', onClosed);
   win.webContents.on('new-window', function (e, url) {
     e.preventDefault();
     require('electron').shell.openExternal(url);
   });
 
+  win.on('closed', winClosed);
+
   return win;
 }
 
+app.on('before-quit', (e) => {
+  var choice = electron.dialog.showMessageBoxSync(null,
+    {
+      type: 'question',
+      buttons: ['Yes', 'No'],
+      title: 'Confirm',
+      message: 'Are you sure you want to quit?'
+    });
+
+  if (choice == 1) {
+    log.silly('cancel quitting app');
+    e.preventDefault();
+  } else {
+    log.silly('quitting app');
+  }
+});
+
 app.on('window-all-closed', () => {
-  log.debug('main window all closed');
+  log.silly('windows all closed');
   app.quit();
 });
 
@@ -198,7 +216,7 @@ app.on('ready', () => {
   }
 
   mainWindow.once('ready-to-show', () => {
-    log.debug('main window ready to show');
+    log.silly('main window ready to show');
     if (!isCliCommand()) {
       mainWindow.show();
       mainWindow.maximize();


### PR DESCRIPTION
<!--
Please provide enough information so that others can review your pull request.
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.
The first three fields are mandatory:
-->
**- Summary**
This is a 'sort-off' fix to issue #12 that adds a confirmation dialog box before quitting the application. It would be better if the dialog box only appears if there are unsaved changes, but I did not work out how to do that, so it appears on all quit actions.
<!--
Explain the motivation for making this change.
What existing issue does the pull request solve?
-->

**- Tests**
Manually tested and also passes tests
<!--
Demonstrate the code is solid.
Ensure the the code passes the `npm run-script pretest` and the `npm test` stages.
-->

**- Description for the changelog**
add confirm dialog box before quit
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- Any other info**

<!--
Thanks for submitting a pull request!
Please make sure you've read and understood our contributing guidelines;
https://github.com/OWASP/threat-dragon/blob/main/CONTRIBUTING.md
-->
