### PR TITLE
PDF print cancelled if model path not present

### DIFF
--- a/app/services/electron.js
+++ b/app/services/electron.js
@@ -12,7 +12,7 @@ const userDataPath = electron.remote.app.getPath('userData');
 
 function electronservice(common) {
 
-    log.debug('Electron Service logging verbosity level', logLevel);
+    log.debug('Electron Service: logging verbosity level', logLevel);
 
     var logInfo = common.logger.getLogFn('electron service', 'info');
     var logError = common.logger.getLogFn('electron service', 'error');
@@ -49,16 +49,16 @@ function electronservice(common) {
     }
 
     function save(onSave, onNoSave) {
-        log.debug('Electron Service save');
+        log.debug('Electron Service: save');
         dialog.showSaveDialog(remote.getCurrentWindow(), {
             defaultPath: "new-model.json",
             filters: [{ name: 'Threat Models', extensions: ['json'] }]
         }).then(result => {
             if (result.canceled) {
-                log.warn('Electron Service save canceled');
+                log.warn('Electron Service: save canceled');
                 onNoSave();
             } else {
-                log.info('Electron Service save to file', result.filePath);
+                log.info('Electron Service: save to file', result.filePath);
                 onSave(result.filePath);
             }
         }).catch(err => {
@@ -67,16 +67,22 @@ function electronservice(common) {
     }
 
     function saveAsPDF(defaultPath, onSave, onNoSave) {
-        log.debug('Electron Service save PDF');
+        log.debug('Electron Service: save PDF using path:', defaultPath);
+        if (defaultPath == null) {
+            logInfo('No path to model found, ensure model has been saved');
+            log.warn('Electron Service: no valid path, no PDF print');
+            onNoSave();
+            return;
+        }
         dialog.showSaveDialog(remote.getCurrentWindow(), {
             defaultPath: defaultPath,
             filters: [{ name: 'PDF files', extensions: ['pdf'] }]
         }).then(result => {
             if (result.canceled) {
-                log.warn('Electron Service save PDF canceled');
+                log.warn('Electron Service: save PDF canceled');
                 onNoSave();
             } else {
-                log.info('Electron Service save to PDF file', result.filePath);
+                log.info('Electron Service: save to PDF file', result.filePath);
                 onSave(result.filePath);
             }
         }).catch(err => {
@@ -85,15 +91,15 @@ function electronservice(common) {
     }
 
     function open(onOpen, onNoOpen) {
-        log.debug('Electron Service open');
+        log.debug('Electron Service: open');
         dialog.showOpenDialog(remote.getCurrentWindow(), {
             filters: [{ name: 'Threat Models', extensions: ['json'] }, { name: 'All Files', extensions: ['*'] }]
         }).then(result => {
             if (result.canceled) {
-                log.info('Electron Service open canceled');
+                log.info('Electron Service: open canceled');
                 onNoOpen();
             } else {
-                log.info('Electron Service open file', result.filePaths);
+                log.info('Electron Service: open file', result.filePaths);
                 onOpen(result.filePaths);
             }
         }).catch(err => {

--- a/test/spec/threatmodels/desktopreport_spec.js
+++ b/test/spec/threatmodels/desktopreport_spec.js
@@ -214,7 +214,7 @@ describe('desktopreport controller', function () {
                 expect(options.pageSize).toEqual('A4');
             });
 
-            xit('should not save the PDF file', function() {
+            xit('should not save the PDF file on cancel', function() {
 
                 var testData = 'data';
                 mockElectron.currentWindow.webContents.printToPDF = function(settings, callback) {
@@ -222,6 +222,24 @@ describe('desktopreport controller', function () {
                 };
                 var done = jasmine.createSpy('done');
                 mockElectron.dialog.saveAsPDF = function(defaultPath, onSave, onCancel) {
+                    onCancel();
+                }
+                $controller('desktopreport as vm', { $scope: $scope });
+                $scope.$apply();
+                $scope.vm.savePDF(done);
+
+                expect(done).toHaveBeenCalled();
+            });
+
+            xit('should not save the PDF file on null path', function() {
+
+                var testData = 'data';
+                var nullPath;
+                mockElectron.currentWindow.webContents.printToPDF = function(settings, callback) {
+                    callback(null, testData);
+                };
+                var done = jasmine.createSpy('done');
+                mockElectron.dialog.saveAsPDF = function(nullPath, onSave, onCancel) {
                     onCancel();
                 }
                 $controller('desktopreport as vm', { $scope: $scope });


### PR DESCRIPTION
**Summary**
This is a fix for issue #94 "Save PDF doesn't work" raised by @sherbo
If the demo model is loaded and not saved then the model path is null. This throws an error and we end up with a blank screen. The fix checks for this condition and returns an error message. 

**Description for the changelog**
PDF print cancelled if model path not present

**Other info**
The test for this has been added, but the whole section for PDF print is skipped. I have raised a separate issue for this #99 "PDF print tests are skipped"

